### PR TITLE
Fix imports to use correct package name.

### DIFF
--- a/etc/item-item.groovy
+++ b/etc/item-item.groovy
@@ -1,5 +1,5 @@
-import org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
-import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
+import org.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
+import org.lenskit.transform.normalize.UserVectorNormalizer
 import org.lenskit.api.ItemScorer
 import org.lenskit.baseline.BaselineScorer
 import org.lenskit.baseline.ItemMeanRatingItemScorer


### PR DESCRIPTION
This will fix the following compilation errors:

```
Caused by: org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
/home/case/projects/lenskit-hello/etc/item-item.groovy: 1: unable to resolve class org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
 @ line 1, column 1.
   import org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
   ^

/home/case/projects/lenskit-hello/etc/item-item.groovy: 2: unable to resolve class org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
 @ line 2, column 1.
   import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
   ^
```

